### PR TITLE
Changes source of MAU/DAU from external to internal

### DIFF
--- a/src/modules/brave.ts
+++ b/src/modules/brave.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import { debugLOG } from "../utils.js";
+import { debugLOG, roundToNearest } from "../utils.js";
 
 const ADS_SERVER_STATS_CREDENTIAL = process.env.ADS_SERVER_STATS_CREDENTIAL;
 
@@ -71,6 +71,14 @@ export interface CryptoCompareData {
   conversionSymbol: string;
 }
 
+interface MauDauResponse {
+  [date: string]: {
+    browser_mau_adjusted: number;
+    browser_mau_historical: number;
+    browser_dau_monthly_avg: number;
+  };
+}
+
 // TODO: Sparse data; nothing after 2022-04-01.
 export async function getRewardsPayoutRecordHistory(): Promise<
   RewardsInstanceCount[]
@@ -85,6 +93,23 @@ export async function getRewardsPayoutRecordHistory(): Promise<
   return response.sort((a: RewardsInstanceCount, b: RewardsInstanceCount) =>
     a.date.localeCompare(b.date)
   );
+}
+
+export async function getMauDau(): Promise<MauDauResponse> {
+  if (!process.env.BRAVE_MAUDAU_URL) {
+    throw new Error("Environment variable BRAVE_MAUDAU_URL is not set");
+  }
+  debugLOG("Requesting MAU/DAU data from BRAVE_MAUDAU_URL");
+  const endpoint = process.env.BRAVE_MAUDAU_URL;
+  const response = await fetch(endpoint).then((res) => res.json()) as MauDauResponse;
+  // Round the figures to the nearest 100K
+  for (const date of Object.keys(response) as (keyof typeof response)[]) {
+    for (const key of Object.keys(response[date]) as (keyof typeof response[typeof date])[]) {
+      response[date][key] = roundToNearest(response[date][key], 1e5);
+    }
+  }
+  debugLOG("Retrieved MAU/DAU data from BRAVE_MAUDAU_URL");
+  return response;
 }
 
 export async function getBATInfo(): Promise<TokenInfo> {

--- a/src/modules/brave.ts
+++ b/src/modules/brave.ts
@@ -103,9 +103,11 @@ export async function getMauDau(): Promise<MauDauResponse> {
   const endpoint = process.env.BRAVE_MAUDAU_URL;
   const response = await fetch(endpoint).then((res) => res.json()) as MauDauResponse;
   // Round the figures to the nearest 100K
-  for (const date of Object.keys(response) as (keyof typeof response)[]) {
-    for (const key of Object.keys(response[date]) as (keyof typeof response[typeof date])[]) {
-      response[date][key] = roundToNearest(response[date][key], 1e5);
+  for (const date in response) {
+    const entry = response[date as keyof typeof response];
+    for (const key in entry) {
+      const tKey = key as keyof typeof entry;
+      entry[tKey] = roundToNearest(entry[tKey], 1e5);
     }
   }
   debugLOG("Retrieved MAU/DAU data from BRAVE_MAUDAU_URL");

--- a/src/modules/braveBATInfo.ts
+++ b/src/modules/braveBATInfo.ts
@@ -1,20 +1,6 @@
 import fetch from "node-fetch";
 import { channelLabels, debugLOG } from "../utils.js";
 
-type MAUDAULabels = "Brave Browser MAU (M)" | "Brave Browser DAU (M)";
-
-interface ActiveUsers {
-  labels: string[];
-  data: {
-    [key in MAUDAULabels]: number[];
-  };
-}
-
-interface ActiveUsersSet {
-  mau: ActiveUsers;
-  dau: ActiveUsers;
-}
-
 interface GrowthRecord {
   record_date: string;
   total: number;
@@ -22,30 +8,6 @@ interface GrowthRecord {
 
 interface CategoryGrowthStats {
   [key: string]: Record<string, number>;
-}
-
-async function getUsersMAU(): Promise<ActiveUsers> {
-  debugLOG("Requesting MAUs from BraveBAT.info");
-  const endpoint = `https://bravebat.info/charts/mau`;
-  const response = (await (await fetch(endpoint)).json()) as ActiveUsers;
-  debugLOG("Retrieved MAUs from BraveBAT.info");
-  return response;
-}
-
-async function getUsersDAU(): Promise<ActiveUsers> {
-  debugLOG("Requesting DAUs from BraveBAT.info");
-  const endpoint = `https://bravebat.info/charts/dau`;
-  const response = (await (await fetch(endpoint)).json()) as ActiveUsers;
-  debugLOG("Retrieved DAUs from BraveBAT.info");
-  return response;
-}
-
-export async function getUsers(): Promise<ActiveUsersSet> {
-  debugLOG("Requesting users from BraveBAT.info");
-  const mau = await getUsersMAU();
-  const dau = await getUsersDAU();
-  debugLOG("Retrieved users from BraveBAT.info");
-  return { mau, dau };
 }
 
 export async function getCreatorGrowth() {


### PR DESCRIPTION
Updates are published each month (typically via x.com/brendaneich), and then reflected on the community site bravebat.info. We've been retrieving the MAU and DAU figures from bravebat.info for quite some time, but are now serving the data from our own endpoint. For this reason, we can move closer to complete-automation of these figures by leaning on the internal source, rather than leveraging the community source.