### PR TITLE
Update Twitter label to 'X (formerly Twitter)'

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export interface TransparencyFile {
 
 export const channelLabels = {
   website: 'Websites',
-  twitter: 'Twitter',
+  twitter: 'X (formerly Twitter)',
   youtube: 'YouTube',
   reddit: 'Reddit',
   github: 'GitHub',


### PR DESCRIPTION
...maybe we don't still need to say `(formerly Twitter)`?