### PR TITLE
Revert "chore: updates Twitter label to 'X (formerly Twitter)'"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export interface TransparencyFile {
 
 export const channelLabels = {
   website: 'Websites',
-  twitter: 'X (formerly Twitter)',
+  twitter: 'Twitter',
   youtube: 'YouTube',
   reddit: 'Reddit',
   github: 'GitHub',


### PR DESCRIPTION
This reverts commit 8becfd054a1339f0cd3f4235e01771a2b80de976.
